### PR TITLE
Closes #30 Removed Build Resume link from resume.html

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -135,7 +135,6 @@
         <ul>
             <li><a href="index.html">Home</a></li>
             <li><a href="about.html">About</a></li>
-            <li><a href="resume.html">Build Resume</a></li>
         </ul>
     </nav>
     <form id="resumeForm">


### PR DESCRIPTION
This PR removes the 'Build Resume' link from the resume.html, as it unnecessarily routed to the same page. The navigation is now cleaner and more user-friendly.